### PR TITLE
Updated installation instructions to contain exact library versions aiming to avoid execution problems

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install
 
-The correct functioning of this repository depends on the right versioning of some of its libraries, specially OpenMMLab. Below you'll see a step-by-step on how to setup them. 
+The correct functioning of this repository depends on the right versioning of some of its libraries, especially OpenMMLab. Below you'll see a step-by-step on how to set them up. 
 
 ## Requirements
 
@@ -39,4 +39,4 @@ python -m pip install git+https://github.com/cocodataset/panopticapi.git \
                       tqdm terminaltables pycocotools scipy tqdm ftfy regex timm scikit-image kornia
 ```
 
-After all the steps, you should have a functional environment for the execution of the codebase.
+After all the steps, you should have a functional environment for executing the codebase.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,48 +1,42 @@
-Install CUDA
-```commandline
-conda install --channel "nvidia/label/cuda-12.1.0" cuda-toolkit
+# Install
+
+The correct functioning of this repository depends on the right versioning of some of its libraries, specially OpenMMLab. Below you'll see a step-by-step on how to setup them. 
+
+## Requirements
+
+- [CUDA](https://developer.nvidia.com/cuda-toolkit)
+- [Anaconda](https://www.anaconda.com/docs/getting-started/anaconda/install) or [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install)
+
+## Setup
+
+1. Create a `conda` environment:
+```bash
+conda create -n omg-seg python=3.10
+conda activate omg-seg
 ```
 
-Install PyTorch:
-```commandline
-conda install pytorch torchvision torchaudio pytorch-cuda==12.1 -c pytorch -c nvidia
+2. Install PyTorch:
+```bash
+# CUDA 11.8
+conda install pytorch==2.0.1 torchvision==0.15.2 pytorch-cuda=11.8 -c pytorch -c nvidia
+# CUDA 11.7
+conda install pytorch==2.0.1 torchvision==0.15.2 pytorch-cuda=11.7 -c pytorch -c nvidia
 ```
 
-Or install with CUDA11.8
-```commandline
-conda install pytorch torchvision torchaudio cuda-toolkit pytorch-cuda==11.8 -c pytorch -c "nvidia/label/cuda-11.8.0"
+3. Install OpenMMLab libraries
+
+```bash
+pip install -U openmim
+mim install mmcv==2.0.1 mmengine==0.8.5 mmdet==3.1.0 mmsegmentation==1.1.1 mmpretrain==1.0.1
 ```
 
-Install mmengine:
-```commandline
-python -m pip install https://github.com/open-mmlab/mmengine/archive/refs/tags/v0.8.5.zip
-```
-
-Install mmcv: (Make sure you use the correct mmcv version as our default setting)
-
-Please see the doc here to find your matched mmcv version. [doc](https://mmcv.readthedocs.io/en/latest/get_started/installation.html).
-You can install pre-build mmcv for easier usage. Make sure your mmdetection is v3.1.0 version.
-
-Here, we provide our experimental mmcv version.
-```commandline
-TORCH_CUDA_ARCH_LIST="8.0" TORCH_NVCC_FLAGS="-Xfatbin -compress-all" CUDA_HOME=$(dirname $(dirname $(which nvcc))) LD_LIBRARY_PATH=$(dirname $(dirname $(which nvcc)))/lib MMCV_WITH_OPS=1 FORCE_CUDA=1 python -m pip install git+https://github.com/open-mmlab/mmcv.git@4f65f91db6502d990ce2ee5de0337441fb69dd10
-```
-
-Install other openmmlab packages:
-```commandline
-python -m pip install \
-https://github.com/open-mmlab/mmdetection/archive/refs/tags/v3.1.0.zip \
-https://github.com/open-mmlab/mmsegmentation/archive/refs/tags/v1.1.1.zip \
-https://github.com/open-mmlab/mmpretrain/archive/refs/tags/v1.0.1.zip
-```
-
-Install extra packages:
-```commandline
+4. Install the remaining libraries
+```bash
 python -m pip install git+https://github.com/cocodataset/panopticapi.git \
-git+https://github.com/HarborYuan/lvis-api.git \
-tqdm terminaltables pycocotools scipy tqdm ftfy regex timm scikit-image kornia
+                      git+https://github.com/HarborYuan/lvis-api.git \
+                      "numpy<2" \
+                      opencv-python==4.8.1.78 \
+                      tqdm terminaltables pycocotools scipy tqdm ftfy regex timm scikit-image kornia
 ```
 
-The default environment is openmmlab on Shanghai AI server.
-
-We suggest using mmcv 2.x with mmdet3.x version for this repo.
+After all the steps, you should have a functional environment for the execution of the codebase.


### PR DESCRIPTION
According to Issue https://github.com/lxtGH/OMG-Seg/issues/46, there's an error when users attempt to execute the OMG-Seg demo pipeline with improper versions of OpenMMLab's libraries. To prevent any further issues on this matter, I have added the exact chain of commands I took to set up a conda environment to function properly with the demo script. 